### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-to-azure.yml
+++ b/.github/workflows/dependabot-to-azure.yml
@@ -1,5 +1,8 @@
 name: Create Azure Board Bug from Dependabot PR
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
Potential fix for [https://github.com/Jeetpentester/MYSITE/security/code-scanning/9](https://github.com/Jeetpentester/MYSITE/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow does not use the `GITHUB_TOKEN` directly, we can set its permissions to `contents: read`, which is the minimal permission required for most workflows. This change should be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
